### PR TITLE
Change from JQL query to filter ID and update to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0 - Filter ID Support
+## 0.4.0 - Filter ID Support
 * Replace jql_query parameter with filter_id parameter
 * Update API endpoint to use filter-based search
 * Add debug logging for troubleshooting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0 - Filter ID Support
+* Replace jql_query parameter with filter_id parameter
+* Update API endpoint to use filter-based search
+* Add debug logging for troubleshooting
+* Improve user experience with filter management
+
 ## 0.1.0 - First Release
 * Every feature added
 * Every bug fixed

--- a/lib/pull-jira-tasks.js
+++ b/lib/pull-jira-tasks.js
@@ -6,7 +6,7 @@ import axios from "axios";
 const NAMESPACE = "pull-jira-tasks";
 const ENVS = {
   token: "",
-  jql_query: "",
+  filter_id: "",
   org_name: "",
 };
 
@@ -26,10 +26,10 @@ const getENV = () => {
 };
 
 const getTasks = () => {
-  const { token, jql_query, org_name } = ENVS;
+  const { token, filter_id, org_name } = ENVS;
   return axios
     .get(
-      `https://${org_name}.atlassian.net/rest/api/3/search?jql=${jql_query}`,
+      `https://${org_name}.atlassian.net/rest/api/3/search/jql?jql=filter=${filter_id}&fields=*all`,
       {
         headers: {
           Authorization: `Basic ${token}`,
@@ -37,10 +37,12 @@ const getTasks = () => {
       }
     )
     .then((response) => {
+      console.log(response)
       return response.data.issues.map((issue) => {
         const issueKey = issue.key;
+        const title = issue.fields.summary;
         return {
-          title: issue.fields.summary,
+          title: title,
           url: `https://${org_name}.atlassian.net/browse/${issueKey}`,
         };
       });
@@ -79,10 +81,9 @@ module.exports = {
         echo -n "your-email@example.com:your-api-token" | base64`,
       type: "string",
     },
-    jql_query: {
-      title: "JQL Query",
-      description: `create query here, https://{{your org}}.atlassian.net/issues/.
-        Paste the request parameters(jql) that were added to the URL after query creation.`,
+    filter_id: {
+      title: "Filter ID",
+      description: `Please obtain the ID of the filter you want to use from the URL below: https://{your org name}.atlassian.net/issues/?filter={filter_id}`,
       type: "string",
     },
     org_name: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "pull-jira-tasks",
-      "version": "0.0.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9"


### PR DESCRIPTION
## Summary
• Replace jql_query parameter with filter_id parameter for easier filter management
• Update API endpoint to use filter-based search instead of direct JQL
• Add debug logging to help with troubleshooting
• Update version to 0.3.0

## Test plan
- [ ] Verify the filter_id parameter works correctly
- [ ] Test that API calls return expected results
- [ ] Confirm backward compatibility is maintained

🤖 Generated with [Claude Code](https://claude.ai/code)